### PR TITLE
add downstream logic for dbt_artifacts_less

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -20,6 +20,10 @@ target-path: "target"
 clean-targets:         
     - "dbt_modules"
 
+vars:
+  dbt_artifacts:
+    +schema: dbt_artifacts_proserv
+
 seeds:
   +quote_columns: false
 
@@ -27,3 +31,6 @@ models:
   dbt_proserv:
       marts:
           +materialized: table
+
+on-run-end:
+  - "{{ dbt_artifacts.upload_results(results) }}"  # dbt_artifacts (or dbt_artifacts_less)

--- a/macros/get_unique_nodes.sql
+++ b/macros/get_unique_nodes.sql
@@ -27,14 +27,18 @@
             {{ exceptions.raise_compiler_error("Invalid type input: `" ~ type ~ "`. Type should be one of ['model', 'test', 'snapshot', 'seed', 'source', 'snapshot']") }}
         {%- endif %}
 
-        -- return nodes for sql where clause
-        (
-        {%- for unique_node in unique_nodes %}
-            '{{ unique_node }}' {%- if not loop.last %},{% endif -%}
-        {%- endfor %}
-        )
+        {% if unique_nodes | length > 0 %}        
+            -- return nodes for sql where clause
+            (
+            {%- for unique_node in unique_nodes %}
+                '{{ unique_node }}' {%- if not loop.last %},{% endif -%}
+            {%- endfor %}
+            )
+        {% else %}
+            ('no_nodes_of_this_type')
+        {% endif %}
     {% else %}
-        {{ (true) }}
+        (true)
     {% endif %}
 
 

--- a/macros/get_unique_nodes.sql
+++ b/macros/get_unique_nodes.sql
@@ -1,0 +1,41 @@
+{# output a set of nodes by type #}
+{# 
+    This is used in dbt_artifacts snapshots
+    to determine what nodes currently exist, 
+    so we can invalidate hard deletes from source
+#}
+
+{% macro get_unique_nodes(type='model') %}
+    {%- set unique_nodes=[] %}
+    {% if execute %}
+        {%- if type in ['model', 'test', 'snapshot', 'seed', 'models', 'tests', 'snapshots', 'seeds'] %}
+            {%- set nodes = graph.nodes.values() | selectattr('resource_type', "equalto", type) %}
+            {%- for node in nodes %}
+                {%- do unique_nodes.append(node.unique_id) %}
+            {%- endfor %}
+        {%- elif type in ['sources', 'source'] %}
+            {%- set nodes = graph.sources.values() %}
+            {%- for node in nodes %}
+                {%- do unique_nodes.append(node.unique_id) %}
+            {%- endfor %}
+        {%- elif type in ['exposures', 'exposure'] %}
+            {%- set nodes = graph.exposures.values() %}
+            {%- for node in nodes %}
+                {%- do unique_nodes.append(node.unique_id) %}
+            {%- endfor %}
+        {%- else %}
+            {{ exceptions.raise_compiler_error("Invalid type input: `" ~ type ~ "`. Type should be one of ['model', 'test', 'snapshot', 'seed', 'source', 'snapshot']") }}
+        {%- endif %}
+
+        -- return nodes for sql where clause
+        (
+        {%- for unique_node in unique_nodes %}
+            '{{ unique_node }}' {%- if not loop.last %},{% endif -%}
+        {%- endfor %}
+        )
+    {% else %}
+        {{ (true) }}
+    {% endif %}
+
+
+{% endmacro %}

--- a/models/marts/dbt_artifacts_less/dbt_artifacts_invocations_and_objects.sql
+++ b/models/marts/dbt_artifacts_less/dbt_artifacts_invocations_and_objects.sql
@@ -1,0 +1,79 @@
+with
+
+invocations as (
+    select * from {{ ref('dbt_invocations') }}
+),
+objects as (
+    select * from {{ ref('dbt_objects') }}
+),
+
+final as (
+    select
+        invocations.execution_id,
+        invocations.execution_type,
+        invocations.command_invocation_id,
+        invocations.node_id,
+        invocations.run_started_at,
+        invocations.was_full_refresh,
+        invocations.thread_id,
+        invocations.status,
+        invocations.compile_started_at,
+        invocations.query_completed_at,
+        invocations.total_node_runtime,
+        invocations.rows_affected,
+        invocations.materialization,
+        invocations.schema,
+        invocations.name,
+        invocations.alias,
+        invocations.failures,
+        invocations.message,
+        invocations.query_id,
+        invocations.dbt_version,
+        invocations.project_name,
+        invocations.invocation_started_at,
+        invocations.dbt_command,
+        invocations.full_refresh_flag,
+        invocations.target_profile_name,
+        invocations.target_name,
+        invocations.target_schema,
+        invocations.target_threads,
+        invocations.dbt_cloud_project_id,
+        invocations.dbt_cloud_job_id,
+        invocations.dbt_cloud_run_id,
+        invocations.dbt_cloud_run_reason_category,
+        invocations.dbt_cloud_run_reason,
+        invocations.env_vars,
+        invocations.dbt_vars,
+        invocations.invocation_args,
+        invocations.dbt_custom_envs,
+        invocations.dbt_cloud_environment_name,
+        invocations.dbt_cloud_environment_type,
+        objects.dbt_scd_id,
+        objects.database as object_database,
+        objects.schema as object_schema,
+        objects.name as object_name,
+        objects.alias as object_alias,
+        objects.source_name,
+        objects.test_name,
+        objects.test_severity_config,
+        objects.test_depends_on_columns,
+        objects.depends_on_nodes,
+        objects.package_name,
+        objects.path,
+        objects.materialization as object_materialization,
+        objects.tags,
+        objects.meta,
+        objects.dbt_updated_at,
+        objects.dbt_valid_from
+
+    from invocations 
+    left join objects
+        on invocations.node_id = objects.node_id
+        and invocations.execution_type = objects.execution_type
+        and invocations.dbt_cloud_environment_name = objects.dbt_cloud_environment_name
+        and invocations.dbt_cloud_environment_type = objects.dbt_cloud_environment_type
+        and invocations.run_started_at >= objects.dbt_valid_from
+        and (invocations.run_started_at < objects.dbt_valid_to or objects.dbt_valid_to is null)
+)
+
+select * from final

--- a/models/marts/dbt_artifacts_less/dbt_current_models.sql
+++ b/models/marts/dbt_artifacts_less/dbt_current_models.sql
@@ -1,0 +1,107 @@
+with
+    base as (select * from {{ ref("dbt_artifacts_models") }}),
+    model_executions as (select * from {{ ref("model_executions") }}),
+    latest_models as (
+
+        /* Retrieves the models present in the most recent run */
+        select * from base where dbt_valid_to is null
+
+    ),
+
+    latest_models_runs as (
+
+        /* Retreives all successful run information for the models present in the most
+        recent run and ranks them based on query completion time */
+        select
+            model_executions.node_id,
+            model_executions.was_full_refresh,
+            model_executions.query_completed_at,
+            model_executions.total_node_runtime,
+            model_executions.rows_affected,
+            /* Row number by refresh and node ID */
+            row_number() over (
+                partition by latest_models.node_id, model_executions.was_full_refresh
+                order by model_executions.query_completed_at desc  /* most recent ranked first */
+            ) as run_idx,
+            /* Row number by node ID */
+            row_number() over (
+                partition by latest_models.node_id order by model_executions.query_completed_at desc  /* most recent ranked first */
+            ) as run_idx_id_only
+        from model_executions
+        inner join latest_models on model_executions.node_id = latest_models.node_id
+        where model_executions.status = 'success'
+
+    ),
+
+    latest_model_stats as (
+
+        select
+            node_id,
+            max(
+                case
+                    when was_full_refresh
+                    then query_completed_at
+                end
+            ) as last_full_refresh_run_completed_at,
+            max(
+                case
+                    when was_full_refresh
+                    then total_node_runtime
+                end
+            ) as last_full_refresh_run_total_runtime,
+            max(
+                case
+                    when was_full_refresh
+                    then rows_affected
+                end
+            ) as last_full_refresh_run_rows_affected,
+            max(case when run_idx_id_only = 1 then query_completed_at end) as last_run_completed_at,
+            max(
+                case when run_idx_id_only = 1 then total_node_runtime end
+            ) as last_run_total_runtime,
+            max(case when run_idx_id_only = 1 then rows_affected end) as last_run_rows_affected,
+            max(
+                case
+                    when not was_full_refresh
+                    then query_completed_at
+                end
+            ) as last_incremental_run_completed_at,
+            max(
+                case
+                    when not was_full_refresh
+                    then total_node_runtime
+                end
+            ) as last_incremental_run_total_runtime,
+            max(
+                case
+                    when not was_full_refresh
+                    then rows_affected
+                end
+            ) as last_incremental_run_rows_affected
+        from latest_models_runs
+        where run_idx = 1
+        group by node_id
+
+    ),
+
+    final as (
+
+        select
+            latest_models.*,
+            latest_model_stats.last_full_refresh_run_completed_at,
+            latest_model_stats.last_full_refresh_run_total_runtime,
+            latest_model_stats.last_full_refresh_run_rows_affected,
+            latest_model_stats.last_run_completed_at,
+            latest_model_stats.last_run_total_runtime,
+            latest_model_stats.last_run_rows_affected,
+            latest_model_stats.last_incremental_run_completed_at,
+            latest_model_stats.last_incremental_run_total_runtime,
+            latest_model_stats.last_incremental_run_rows_affected
+        from latest_models
+        left join latest_model_stats on latest_models.node_id = latest_model_stats.node_id
+
+    )
+
+select *
+from final
+

--- a/models/marts/dbt_artifacts_less/dbt_invocations.sql
+++ b/models/marts/dbt_artifacts_less/dbt_invocations.sql
@@ -1,0 +1,252 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key=['execution_id'],
+        on_schema_change='append_new_columns',
+    )
+}}
+
+with
+model_raw as (
+    select
+        {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }} as execution_id,
+        'model' as execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        {{ split_part("thread_id", "'-'", 2) }} as thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        materialization,
+        schema,
+        name,
+        alias,
+        message,
+        adapter_response
+    from {{ ref("model_executions") }}
+    where 1=1
+    {% if is_incremental() %}
+        -- this filter will only be applied on an incremental run
+        and run_started_at > (select max(tablex.run_started_at) from {{ this }} as tablex)
+    {% endif %}    
+),
+
+test_raw as (
+    select
+        {{ dbt_artifacts.generate_surrogate_key(['command_invocation_id', 'node_id']) }} as execution_id,
+        'test' as execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        {{ split_part('thread_id', "'-'", 2) }} as thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        failures,
+        message,
+        adapter_response
+    from {{ ref('test_executions') }}
+    where 1=1
+    {% if is_incremental() %}
+        -- this filter will only be applied on an incremental run
+        and run_started_at > (select max(tablex.run_started_at) from {{ this }} as tablex)
+    {% endif %}
+),
+
+snapshot_raw as (
+    select
+        {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }} as execution_id,
+        'snapshot' as execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        {{ split_part("thread_id", "'-'", 2) }} as thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        materialization,
+        schema,
+        name,
+        alias,
+        message,
+        adapter_response
+    from {{ ref("snapshot_executions") }}
+    where 1=1
+    {% if is_incremental() %}
+        -- this filter will only be applied on an incremental run
+        and run_started_at > (select max(tablex.run_started_at) from {{ this }} as tablex)
+    {% endif %}    
+),
+
+seed_raw as (
+    select
+        {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }} as execution_id,
+        'seed' as execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        {{ split_part("thread_id", "'-'", 2) }} as thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        materialization,
+        schema,
+        name,
+        alias,
+        message,
+        adapter_response
+    from {{ ref("seed_executions") }}
+    where 1=1
+    {% if is_incremental() %}
+        -- this filter will only be applied on an incremental run
+        and run_started_at > (select max(tablex.run_started_at) from {{ this }} as tablex)
+    {% endif %}    
+),
+
+invocation_raw as (
+    select * from {{ ref('invocations') }}
+    where 1=1
+    {% if is_incremental() %}
+        -- this filter will only be applied on an incremental run
+        and run_started_at > (select max(tablex.run_started_at) from {{ this }} as tablex)
+    {% endif %}     
+),
+
+all_invocations as (
+    select
+        execution_id,
+        execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        materialization,
+        schema,
+        name,
+        alias,
+        null as failures,
+        message,
+        adapter_response:query_id::string as query_id 
+    from model_raw
+
+    union all 
+
+    select
+        execution_id,
+        execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        'test' as materialization,
+        'test' as schema,
+        'test' as name,
+        'test' as alias,
+        failures,
+        message,
+        adapter_response:query_id::string as query_id
+    from test_raw
+    
+    union all
+
+    select
+        execution_id,
+        execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        materialization,
+        schema,
+        name,
+        alias,
+        null as failures,
+        message,
+        adapter_response:query_id::string as query_id 
+    from snapshot_raw     
+
+    union all
+
+    select
+        execution_id,
+        execution_type,
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        was_full_refresh,
+        thread_id,
+        status,
+        compile_started_at,
+        query_completed_at,
+        total_node_runtime,
+        rows_affected,
+        materialization,
+        schema,
+        name,
+        alias,
+        null as failures,
+        message,
+        adapter_response:query_id::string as query_id 
+    from seed_raw     
+),
+
+final as (
+    select 
+        all_invocations.*,
+        invocation_raw.dbt_version,
+        invocation_raw.project_name,
+        invocation_raw.run_started_at as invocation_started_at,
+        invocation_raw.dbt_command,
+        invocation_raw.full_refresh_flag,
+        invocation_raw.target_profile_name,
+        invocation_raw.target_name,
+        invocation_raw.target_schema,
+        invocation_raw.target_threads,
+        invocation_raw.dbt_cloud_project_id,
+        invocation_raw.dbt_cloud_job_id,
+        invocation_raw.dbt_cloud_run_id,
+        invocation_raw.dbt_cloud_run_reason_category,
+        invocation_raw.dbt_cloud_run_reason,
+        invocation_raw.dbt_cloud_environment_name,
+        invocation_raw.dbt_cloud_environment_type,
+        invocation_raw.env_vars,
+        invocation_raw.dbt_vars,
+        invocation_raw.invocation_args,
+        invocation_raw.dbt_custom_envs
+    from all_invocations 
+    left join invocation_raw
+        on all_invocations.command_invocation_id = invocation_raw.command_invocation_id
+)
+ 
+select * from final

--- a/models/marts/dbt_artifacts_less/dbt_model_latest_results.sql
+++ b/models/marts/dbt_artifacts_less/dbt_model_latest_results.sql
@@ -1,0 +1,53 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+with
+models as (
+    select
+        node_id,
+        name as model_name,
+        database, 
+        schema,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type,
+    from {{ ref('dbt_artifacts_models') }}
+    where dbt_valid_to is null
+),
+
+model_executions as (
+    select
+        node_id,
+        run_started_at,
+        total_node_runtime,
+        status,
+        materialization,
+        rows_affected,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from {{ ref('model_executions') }}
+    left join {{ ref('invocations') }} using (command_invocation_id)
+    qualify row_number() over (partition by node_id, dbt_cloud_environment_name, dbt_cloud_environment_type order by run_started_at desc) = 1
+),
+
+executions as (
+    select 
+        models.node_id,
+        models.model_name,
+        models.database,
+        models.schema,
+        model_executions.materialization,
+        model_executions.status,
+        model_executions.run_started_at,
+        model_executions.total_node_runtime,
+        sum(rows_affected) over (partition by models.node_id, model_executions.run_started_at) as rows_affected
+    from models
+    left join model_executions
+        on models.node_id = model_executions.node_id
+        and models.dbt_cloud_environment_name = model_executions.dbt_cloud_environment_name
+        and models.dbt_cloud_environment_type = model_executions.dbt_cloud_environment_type
+)
+    
+select * from executions

--- a/models/marts/dbt_artifacts_less/dbt_objects.sql
+++ b/models/marts/dbt_artifacts_less/dbt_objects.sql
@@ -1,0 +1,190 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+with
+model_raw as (
+    select
+        dbt_scd_id,
+        node_id,
+        'model' as execution_type,
+        run_started_at,
+        database,
+        schema,
+        name,
+        alias,
+        null as source_name,
+        null as test_name,
+        null as test_severity_config,
+        null as test_depends_on_columns,
+        depends_on_nodes,
+        package_name,
+        path,
+        materialization,
+        tags,
+        meta,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type,
+        dbt_updated_at,
+        dbt_valid_from,
+        dbt_valid_to
+    from {{ ref("dbt_artifacts_models") }}
+),
+
+test_raw as (
+    select
+        dbt_scd_id,
+        node_id,
+        'test' as execution_type,
+        run_started_at,
+        'test' as database,
+        'test' as schema,
+        name,
+        null as alias,
+        null as source_name,
+        test_name,
+        test_severity_config,
+        column_names as test_depends_on_columns,
+        depends_on_nodes,
+        package_name,
+        test_path as path,
+        concat('test ', test_type) as materialization,
+        tags,
+        null as meta,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type,
+        dbt_updated_at,
+        dbt_valid_from,
+        dbt_valid_to
+    from {{ ref('dbt_artifacts_tests') }}
+),
+
+snapshot_raw as (
+    select
+        dbt_scd_id,
+        node_id,
+        'snapshot' as execution_type,
+        run_started_at,
+        database,
+        schema,
+        name,
+        alias,
+        null as source_name,
+        null as test_name,
+        null as test_severity_config,
+        null as test_depends_on_columns,
+        depends_on_nodes,
+        package_name,
+        path,
+        concat('snapshot ', strategy) as materialization,
+        null as tags,
+        meta,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type,
+        dbt_updated_at,
+        dbt_valid_from,
+        dbt_valid_to
+    from {{ ref("dbt_artifacts_snapshots") }}
+),
+
+seed_raw as (
+    select
+        dbt_scd_id,
+        node_id,
+        'seed' as execution_type,
+        run_started_at,
+        database,
+        schema,
+        name,
+        alias,
+        null as source_name,
+        null as test_name,
+        null as test_severity_config,
+        null as test_depends_on_columns,
+        null as depends_on_nodes,
+        package_name,
+        path,
+        'seed' as materialization,
+        null as tags,
+        meta,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type,
+        dbt_updated_at,
+        dbt_valid_from,
+        dbt_valid_to
+    from {{ ref("dbt_artifacts_seeds") }} 
+),
+
+source_raw as (
+    select
+        dbt_scd_id,
+        node_id,
+        'source' as execution_type,
+        run_started_at,
+        database,
+        schema,
+        name,
+        identifier as alias,
+        source_name,
+        null as test_name,
+        null as test_severity_config,
+        null as test_depends_on_columns,
+        null as depends_on_nodes,
+        null as package_name,
+        null as path,
+        'source' as materialization,
+        null as tags,
+        null as meta,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type,
+        dbt_updated_at,
+        dbt_valid_from,
+        dbt_valid_to
+    from {{ ref("dbt_artifacts_sources") }}
+),
+
+exposure_raw as (
+    select
+        dbt_scd_id,
+        node_id,
+        'exposure' as execution_type,
+        run_started_at,
+        null as database,
+        null as schema,
+        name,
+        null as alias,
+        null as source_name,
+        null as test_name,
+        null as test_severity_config,
+        null as test_depends_on_columns,
+        depends_on_nodes,
+        package_name,
+        path,
+        'exposure' as materialization,
+        tags,
+        null as meta,
+        null as dbt_cloud_environment_name,
+        null as dbt_cloud_environment_type,
+        dbt_updated_at,
+        dbt_valid_from,
+        dbt_valid_to
+    from {{ ref("dbt_artifacts_exposures") }}
+),
+
+unioned as (
+    select * from model_raw
+        union all
+    select * from test_raw
+        union all
+    select * from snapshot_raw
+        union all
+    select * from seed_raw
+        union all
+    select * from source_raw
+        union all
+    select * from exposure_raw
+)
+
+select * from unioned

--- a/models/marts/dbt_artifacts_less/dbt_test_latest_results.sql
+++ b/models/marts/dbt_artifacts_less/dbt_test_latest_results.sql
@@ -1,0 +1,134 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+with 
+source_models as (
+    select
+        node_id,
+        name as model_name,
+        database, 
+        schema,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from 
+        {{ ref('dbt_artifacts_models') }}
+    where dbt_valid_to is null
+
+    union all
+    
+    select
+        node_id,
+        name as model_name,
+        database, 
+        schema,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from {{ ref('dbt_artifacts_sources') }}
+    where dbt_valid_to is null
+),
+    
+source_tests as (
+    select
+        node_id,
+        name as test_long_name,
+        test_name as test_short_name,
+        test_severity_config,
+        column_names as test_depends_on_columns,
+        test_type,
+        depends_on_nodes,
+        package_name,
+        test_path,
+        tags,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from {{ ref('dbt_artifacts_tests') }}
+    where dbt_valid_to is null
+),
+
+test_executions as (
+    select 
+        command_invocation_id,
+        node_id,
+        run_started_at,
+        status,
+        failures,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from {{ ref('dbt_artifacts', 'test_executions') }}
+    left join {{ ref('invocations') }} using (command_invocation_id)
+    qualify row_number() over (partition by node_id, dbt_cloud_environment_name, dbt_cloud_environment_type order by run_started_at desc) = 1
+),
+
+failed as (
+    select distinct
+        command_invocation_id,
+        node_id,
+        min(run_started_at) over (partition by node_id) as first_failed_at,
+        status,
+        failures
+    from test_executions
+    where status in ('error','warn')
+),
+
+model_test as (
+    select 
+        source_models.model_name,
+        source_models.node_id,
+        source_models.database,
+        source_models.schema,
+        source_models.dbt_cloud_environment_name,
+        source_models.dbt_cloud_environment_type,
+        source_tests.test_long_name,
+        source_tests.test_short_name,
+        source_tests.test_severity_config,
+        source_tests.test_depends_on_columns,
+        source_tests.test_type,
+        source_tests.depends_on_nodes,
+        source_tests.package_name,
+        source_tests.test_path,
+        source_tests.tags,
+        test_executions.node_id as test_node_id,
+        test_executions.status,
+        test_executions.failures,
+        test_executions.run_started_at,
+        failed.first_failed_at
+    from source_models
+    inner join source_tests
+        on source_models.node_id = source_tests.depends_on_nodes[0]
+        and source_models.dbt_cloud_environment_name = source_tests.dbt_cloud_environment_name
+        and source_models.dbt_cloud_environment_type = source_tests.dbt_cloud_environment_type
+    left join test_executions
+        on source_tests.node_id = test_executions.node_id
+        and test_executions.dbt_cloud_environment_name = source_tests.dbt_cloud_environment_name
+        and test_executions.dbt_cloud_environment_type = source_tests.dbt_cloud_environment_type
+    left join failed
+        on test_executions.command_invocation_id = failed.command_invocation_id
+        and test_executions.node_id = failed.node_id
+)
+
+select
+    model_name,
+    node_id,
+    database,
+    schema,
+    dbt_cloud_environment_name,
+    dbt_cloud_environment_type,
+    test_long_name,
+    test_short_name,
+    test_severity_config,
+    test_depends_on_columns,
+    test_type,
+    depends_on_nodes,
+    package_name,
+    test_path,
+    tags,
+    node_id as test_node_id,
+    status,
+    failures,
+    run_started_at,
+    first_failed_at
+from 
+    model_test

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,8 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.0.0
+  - package: dbt-labs/audit_helper
+    version: 0.7.0
+  - git: https://github.com/dbt-labs/dbt-artifacts-less.git
+    revision: 077e91b7543ae701c95ead3a9783fa5131b88880
+sha1_hash: 6ea4ccf5c7abcb108ae7984bf885c4ca81d4cabb

--- a/packages.yml
+++ b/packages.yml
@@ -3,3 +3,5 @@ packages:
     version: 1.0.0
   - package: dbt-labs/audit_helper
     version: 0.7.0
+  - git: "https://github.com/dbt-labs/dbt-artifacts-less.git" # git URL
+    revision: "main"

--- a/snapshots/dbt_artifacts_less/dbt_artifacts_exposures.sql
+++ b/snapshots/dbt_artifacts_less/dbt_artifacts_exposures.sql
@@ -1,0 +1,44 @@
+{% snapshot dbt_artifacts_exposures %}
+    {{
+        config(
+            target_database='development',
+            target_schema='dbt_pkearns_snapshots',
+            unique_key='node_id',
+            strategy='timestamp',
+            updated_at='run_started_at',
+            invalidate_hard_deletes=true
+        )
+    }}
+
+with
+    
+base as (
+    select * from {{ ref("exposures") }}
+),
+
+enhanced as (
+    select
+        node_id,
+        run_started_at,
+        name,
+        type,
+        owner,
+        maturity,
+        path,
+        description,
+        url,
+        package_name,
+        depends_on_nodes,
+        tags,
+        checksum
+    from base
+    where
+        node_id in 
+        {{ get_unique_nodes(type='exposures') }}
+    qualify ROW_NUMBER() OVER (PARTITION BY node_id ORDER BY run_started_at desc) = 1
+    )
+
+select *
+from enhanced
+
+{% endsnapshot %}

--- a/snapshots/dbt_artifacts_less/dbt_artifacts_models.sql
+++ b/snapshots/dbt_artifacts_less/dbt_artifacts_models.sql
@@ -1,0 +1,46 @@
+{% snapshot dbt_artifacts_models %}
+    {{
+        config(
+            target_database='development',
+            target_schema='dbt_pkearns_snapshots',
+            unique_key='node_id',
+            strategy='timestamp',
+            updated_at='run_started_at',
+            invalidate_hard_deletes=true
+        )
+    }}
+
+with
+    
+base as (
+    select * from {{ ref("models") }}
+),
+
+enhanced as (
+    select
+        node_id,
+        run_started_at,
+        database,
+        schema,
+        name,
+        depends_on_nodes,
+        package_name,
+        path,
+        checksum,
+        materialization,
+        tags,
+        meta,
+        alias,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from base
+    where
+        node_id in 
+        {{ get_unique_nodes(type='model') }}
+    qualify ROW_NUMBER() OVER (PARTITION BY node_id, dbt_cloud_environment_name, dbt_cloud_environment_type ORDER BY run_started_at desc) = 1
+    )
+
+select *
+from enhanced
+
+ {% endsnapshot %}

--- a/snapshots/dbt_artifacts_less/dbt_artifacts_seeds.sql
+++ b/snapshots/dbt_artifacts_less/dbt_artifacts_seeds.sql
@@ -1,0 +1,43 @@
+{% snapshot dbt_artifacts_seeds %}
+    {{
+        config(
+            target_database='development',
+            target_schema='dbt_pkearns_snapshots',
+            unique_key='node_id',
+            strategy='timestamp',
+            updated_at='run_started_at',
+            invalidate_hard_deletes=true
+        )
+    }}
+
+with
+    
+base as (
+    select * from {{ ref("seeds") }}
+),
+
+enhanced as (
+    select
+        node_id,
+        run_started_at,
+        database,
+        schema,
+        name,
+        package_name,
+        path,
+        checksum,
+        meta,
+        alias,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from base
+    where
+        node_id in 
+        {{ get_unique_nodes(type='seed') }}
+    qualify ROW_NUMBER() OVER (PARTITION BY node_id, dbt_cloud_environment_name, dbt_cloud_environment_type ORDER BY run_started_at desc) = 1
+    )
+
+select *
+from enhanced
+
+ {% endsnapshot %}

--- a/snapshots/dbt_artifacts_less/dbt_artifacts_snapshots.sql
+++ b/snapshots/dbt_artifacts_less/dbt_artifacts_snapshots.sql
@@ -1,0 +1,45 @@
+{% snapshot dbt_artifacts_snapshots %}
+    {{
+        config(
+            target_database='development',
+            target_schema='dbt_pkearns_snapshots',
+            unique_key='node_id',
+            strategy='timestamp',
+            updated_at='run_started_at',
+            invalidate_hard_deletes=true
+        )
+    }}
+
+with
+    
+base as (
+    select * from {{ ref("snapshots") }}
+),
+
+enhanced as (
+    select
+        node_id,
+        run_started_at,
+        database,
+        schema,
+        name,
+        depends_on_nodes,
+        package_name,
+        path,
+        checksum,
+        strategy,
+        meta,
+        alias,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from base
+    where
+        node_id in 
+        {{ get_unique_nodes(type='snapshot') }}
+    qualify ROW_NUMBER() OVER (PARTITION BY node_id, dbt_cloud_environment_name, dbt_cloud_environment_type ORDER BY run_started_at desc) = 1
+    )
+
+select *
+from enhanced
+
+ {% endsnapshot %}

--- a/snapshots/dbt_artifacts_less/dbt_artifacts_sources.sql
+++ b/snapshots/dbt_artifacts_less/dbt_artifacts_sources.sql
@@ -1,0 +1,43 @@
+{% snapshot dbt_artifacts_sources %}
+    {{
+        config(
+            target_database='development',
+            target_schema='dbt_pkearns_snapshots',
+            unique_key='node_id',
+            strategy='timestamp',
+            updated_at='run_started_at',
+            invalidate_hard_deletes=true
+        )
+    }}
+
+with
+    
+base as (
+    select * from {{ ref("sources") }}
+),
+
+enhanced as (
+    select
+        node_id,
+        run_started_at,
+        database,
+        schema,
+        source_name,
+        loader,
+        name,
+        identifier,
+        loaded_at_field,
+        checksum,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from base
+    where
+        node_id in 
+        {{ get_unique_nodes(type='sources') }}
+    qualify ROW_NUMBER() OVER (PARTITION BY node_id, dbt_cloud_environment_name, dbt_cloud_environment_type ORDER BY run_started_at desc) = 1
+    )
+
+select *
+from enhanced
+
+ {% endsnapshot %}

--- a/snapshots/dbt_artifacts_less/dbt_artifacts_tests.sql
+++ b/snapshots/dbt_artifacts_less/dbt_artifacts_tests.sql
@@ -1,0 +1,44 @@
+{% snapshot dbt_artifacts_tests %}
+    {{
+        config(
+            target_database='development',
+            target_schema='dbt_pkearns_snapshots',
+            unique_key='node_id',
+            strategy='timestamp',
+            updated_at='run_started_at',
+            invalidate_hard_deletes=true
+        )
+    }}
+
+with
+    
+base as (
+    select * from {{ ref("tests") }}
+),
+
+enhanced as (
+    select
+        node_id,
+        run_started_at,
+        name,
+        test_name,
+        test_severity_config,
+        column_names,
+        test_type,
+        depends_on_nodes,
+        package_name,
+        test_path,
+        tags,
+        dbt_cloud_environment_name,
+        dbt_cloud_environment_type
+    from base
+    where
+        node_id in 
+        {{ get_unique_nodes(type='test') }}
+    qualify ROW_NUMBER() OVER (PARTITION BY node_id, dbt_cloud_environment_name, dbt_cloud_environment_type ORDER BY run_started_at desc) = 1
+    )
+
+select *
+from enhanced
+
+ {% endsnapshot %}


### PR DESCRIPTION
Porting changes from my personal repo to this repo: https://github.com/patkearns10/dbt_workspace/pull/172

<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.13.0"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

Utilizing a modified version of dbt_artifacts:
https://github.com/dbt-labs/dbt-artifacts-less

which changes the dimensional models (`exposures`, `models`, `seeds`, `snapshots`, `sources`, `tests`)
from always inserting every node each time a command is run, to only inserting if it has changed since the last run. This requires utilizing checksums within the dbt_artifacts_less package, and adding snapshots in your downstream models to capture changes over time, but results in much, much smaller source tables.

For example, a customer I am working with has 2 Billion rows in their tests source model and 200 Million in their models source model. This is insane given they currently have 653 models and 6050 data tests.

Original code implemented here:
https://github.com/patkearns10/dbt_workspace/pull/172

## Screenshots:
<!---
Include a screenshot of the relevant section of the updated DAG. You can access
your version of the DAG by running `dbt docs generate && dbt docs serve`.
-->
![image](https://github.com/user-attachments/assets/a97828f6-e6fc-4c81-994f-3015d0f1eff4)
